### PR TITLE
fix case clause error in verify! due to pop_expect setting invalid state

### DIFF
--- a/lib/promox.ex
+++ b/lib/promox.ex
@@ -180,6 +180,23 @@ defmodule Promox do
   def verify!(mock) do
     mock.agent
     |> Agent.get(&Promox.State.get_expects/1)
+    |> tap(fn expects ->
+      Enum.map(expects, fn
+        {{protocol, fun, arity}, nil} ->
+          raise UnexpectedCallError,
+                ~s"""
+                unexpected call to #{Exception.format_mfa(protocol, fun, arity)}
+
+                Usually, this error means that the mock was not used to stub or expect this function.
+                And when this function was called, a Promox.UnexpectedCallError should be raised immediately.
+                But this error was raised from Promox.verify!/1, which means that the above Promox.UnexpectedCallError was rescued.
+                You may also want to check if your code is rescuing more exceptions than it should.
+                """
+
+        _ ->
+          :ok
+      end)
+    end)
     |> Enum.filter(fn {_pfa, {expects, _used_expects}} -> length(expects) > 0 end)
     |> case do
       [] ->

--- a/lib/promox/state.ex
+++ b/lib/promox/state.ex
@@ -35,7 +35,7 @@ defmodule Promox.State do
 
   defp pop_expect(state, pfa) do
     get_and_update_in(state, [:expects, pfa], fn
-      nil -> {nil, {[], []}}
+      nil -> {nil, nil}
       {[], used_expects} -> {nil, {[], used_expects}}
       {[expect | rest], used_expects} -> {expect, {rest, [expect | used_expects]}}
     end)

--- a/lib/promox/state.ex
+++ b/lib/promox/state.ex
@@ -35,7 +35,7 @@ defmodule Promox.State do
 
   defp pop_expect(state, pfa) do
     get_and_update_in(state, [:expects, pfa], fn
-      nil -> {nil, nil}
+      nil -> {nil, {[], []}}
       {[], used_expects} -> {nil, {[], used_expects}}
       {[expect | rest], used_expects} -> {expect, {rest, [expect | used_expects]}}
     end)

--- a/test/promox_test.exs
+++ b/test/promox_test.exs
@@ -96,6 +96,18 @@ defmodule PromoxTest do
       assert Calculable.add(mock, :x) == :stubbed_add
     end
 
+    test "raises if a function gets called if it's expected to be called 0 times" do
+      mock =
+        Promox.new()
+        |> Promox.expect(Calculable, :add, 0, fn _mock, :x -> :stubbed_add end)
+
+      assert_raise(
+        Promox.UnexpectedCallError,
+        "no expectation defined for Calculable.add/2",
+        fn -> Calculable.add(mock, :x) end
+      )
+    end
+
     test "raises if a function gets called after `n` times" do
       mock =
         Promox.new()
@@ -246,6 +258,14 @@ defmodule PromoxTest do
         ~r{unexpected call to Calculable.add/2},
         fn -> Promox.verify!(mock) end
       )
+    end
+
+    test "passes for a mock that expect a function to be called 0 times" do
+      mock =
+        Promox.new()
+        |> Promox.expect(Calculable, :add, 0, fn _mock, :x -> :stubbed_add end)
+
+      assert Promox.verify!(mock) == :ok
     end
 
     test "passes for a mock that satisfies expects" do

--- a/test/promox_test.exs
+++ b/test/promox_test.exs
@@ -231,6 +231,23 @@ defmodule PromoxTest do
       )
     end
 
+    test "fails when UnexpectedCallError gets rescued" do
+      mock = Promox.new()
+
+      try do
+        Calculable.add(mock, 1)
+      rescue
+        _e in [Promox.UnexpectedCallError] ->
+          :ok
+      end
+
+      assert_raise(
+        Promox.UnexpectedCallError,
+        ~r{unexpected call to Calculable.add/2},
+        fn -> Promox.verify!(mock) end
+      )
+    end
+
     test "passes for a mock that satisfies expects" do
       mock =
         Promox.new()


### PR DESCRIPTION
Error was raised when using stub together with expect 
```     
     ** (FunctionClauseError) no function clause matching in anonymous fn/1 in Promox.verify!/1

     The following arguments were given to anonymous fn/1 in Promox.verify!/1:
     
         # 1
         {{Protocol, :callback, 1}, nil}
```